### PR TITLE
refactor(actions): Refactored the `GetActions` model and class tweaks

### DIFF
--- a/StreamerBotPlugin/Commands/ActionAdjustmentCommand.cs
+++ b/StreamerBotPlugin/Commands/ActionAdjustmentCommand.cs
@@ -37,13 +37,13 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         public ActionAdjustmentCommand() : base("Adjustment Action", "Choose and execute your actions with adjustments (Reset sets it to 0)", "Adjustment Action", true)
         {
             this._httpService = HttpService.Instance;
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions().Actions;
             this.MakeProfileAction("tree");
         }
 
         protected override PluginProfileActionData GetProfileActionData()
         {
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions().Actions;
             var tree = new PluginProfileActionTree("Select Windows Settings Application");
 
             tree.AddLevel("Category");
@@ -61,7 +61,7 @@ namespace Loupedeck.StreamerBotPlugin.Commands
 
         protected override void RunCommand(String actionParameter)
         {
-            var action = this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
+            var action = this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
 
             if (action == null)
             {
@@ -73,7 +73,7 @@ namespace Loupedeck.StreamerBotPlugin.Commands
 
         protected override void ApplyAdjustment(String actionParameter, Int32 diff)
         {
-            var action = this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
+            var action = this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
 
             if (action == null)
             {
@@ -84,9 +84,9 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         }
 
         protected override String GetAdjustmentDisplayName(String actionParameter, PluginImageSize imageSize) =>
-            this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
+            this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
 
         protected override String GetCommandDisplayName(String actionParameter, PluginImageSize imageSize) =>
-            this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
+            this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
     }
 }

--- a/StreamerBotPlugin/Commands/ActionAdjustmentCommand.cs
+++ b/StreamerBotPlugin/Commands/ActionAdjustmentCommand.cs
@@ -37,13 +37,13 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         public ActionAdjustmentCommand() : base("Adjustment Action", "Choose and execute your actions with adjustments (Reset sets it to 0)", "Adjustment Action", true)
         {
             this._httpService = HttpService.Instance;
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions().Actions;
             this.MakeProfileAction("tree");
         }
 
         protected override PluginProfileActionData GetProfileActionData()
         {
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions()?.Actions;
             var tree = new PluginProfileActionTree("Select Windows Settings Application");
 
             tree.AddLevel("Category");
@@ -61,7 +61,7 @@ namespace Loupedeck.StreamerBotPlugin.Commands
 
         protected override void RunCommand(String actionParameter)
         {
-            var action = this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
+            var action = this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
 
             if (action == null)
             {
@@ -73,7 +73,7 @@ namespace Loupedeck.StreamerBotPlugin.Commands
 
         protected override void ApplyAdjustment(String actionParameter, Int32 diff)
         {
-            var action = this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
+            var action = this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
 
             if (action == null)
             {
@@ -84,9 +84,9 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         }
 
         protected override String GetAdjustmentDisplayName(String actionParameter, PluginImageSize imageSize) =>
-            this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
+            this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
 
         protected override String GetCommandDisplayName(String actionParameter, PluginImageSize imageSize) =>
-            this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
+            this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
     }
 }

--- a/StreamerBotPlugin/Commands/ActionCommand.cs
+++ b/StreamerBotPlugin/Commands/ActionCommand.cs
@@ -37,13 +37,13 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         public ActionCommand() : base("Action", "Choose and execute your actions", "Action")
         {
             this._httpService = HttpService.Instance;
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions().Actions;
             this.MakeProfileAction("tree");
         }
 
         protected override PluginProfileActionData GetProfileActionData()
         {
-            this._actions = this._httpService.GetActions()?.Actions ?? Array.Empty<Action>();
+            this._actions = this._httpService.GetActions().Actions;
             var tree = new PluginProfileActionTree("Select Windows Settings Application");
 
             tree.AddLevel("Category");
@@ -61,7 +61,7 @@ namespace Loupedeck.StreamerBotPlugin.Commands
 
         protected override void RunCommand(String actionParameter)
         {
-            var action = this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
+            var action = this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter);
 
             if (action == null)
             {
@@ -72,6 +72,6 @@ namespace Loupedeck.StreamerBotPlugin.Commands
         }
 
         protected override String GetCommandDisplayName(String actionParameter, PluginImageSize imageSize) =>
-            this._actions?.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
+            this._actions.FirstOrDefault(a => actionParameter is not null && a.Id == actionParameter)?.Name ?? base.GetCommandDisplayName(actionParameter, imageSize);
     }
 }

--- a/StreamerBotPlugin/Models/GetActions.cs
+++ b/StreamerBotPlugin/Models/GetActions.cs
@@ -27,14 +27,21 @@ namespace Loupedeck.StreamerBotPlugin.Models.Receive
     public class GetActions
     {
         public Int32 Count { get; set; }
-        public Action[] Actions { get; set; }
+        public Action[] Actions { get; set; } = Array.Empty<Action>();
     }
 
     public class Action
     {
         public String Id { get; set; }
         public String Name { get; set; }
-        public String Group { get; set; }
+        
+        private String _group;
+        public String Group
+        {
+            get => this._group;
+            set => this._group = String.IsNullOrEmpty(value) ? "None" : value;
+        }
+        
         public Boolean Enabled { get; set; }
     }
 }


### PR DESCRIPTION
Refactored the `GetActions` model to use an init array so that is ***always*** returns an empty array and not a null or an empty array, minimizing the number of inline null-checks needed. 

Also, tweaked the `Group` property to presume an empty string means "Group of 'None'", which corresponds better with the Streamer.bot software grouping mech. 